### PR TITLE
Lesson 19 - To Allow For All Sync Operations To Run Concurrently

### DIFF
--- a/lesson-p-19/gotut19.go
+++ b/lesson-p-19/gotut19.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+  "time"
+  "fmt"
+  "sync"
+)
+
+var wg sync.WaitGroup
+// This is how we deal with concurrency execution
+
+func say(s string) {
+  for i := 0; i < 3; i++ {
+    fmt.Println(s)
+    time.Sleep(time.Millisecond*100)
+  }
+  wg.Done()
+}
+
+func main() {
+  wg.Add(1)
+  go say("Hey")
+  wg.Add(1)
+  go say("There")
+  wg.Add(1)
+  go say("Hi")
+  wg.Wait()
+}


### PR DESCRIPTION
No need to place set timeout wait, instead utilizing the "sync" package to allow for processes to complete concurrently